### PR TITLE
🩹 空文字時文言、送信ボタン、チェックボックス、国際化の修正

### DIFF
--- a/src/components/project/EmployeeCodeDisplay.vue
+++ b/src/components/project/EmployeeCodeDisplay.vue
@@ -1,11 +1,11 @@
 <template>
   <div>
     <p v-if="employeeCode">
-      {{ $t("app.employee_code", { employeeCode }) }}
+      {{ $t("app.prop_emit.employee.employee_code", { employeeCode }) }}
     </p>
     <DemoAppCheckboxDisplay
-      :isChecked="termsOfUse"
-      :checkedText="$t('checkbox.check')"
+      :isChecked="isSubscribed"
+      :checkedText="$t('app.prop_emit.user.checkbox.check')"
       :uncheckedText="$t('app.prop_emit.user.checkbox.checknull')"
     />
   </div>
@@ -23,7 +23,7 @@ import DemoAppCheckboxDisplay from "@/components/parts/DemoAppBooleanDisplay.vue
 })
 export default class EmployeeCodeDisplay extends Vue {
   @Prop(String) employeeCode;
-  @Prop(Boolean) termsOfUse;
+  @Prop(Boolean) isSubscribed;
 }
 </script>
 

--- a/src/components/project/EmployeeCodeDisplay.vue
+++ b/src/components/project/EmployeeCodeDisplay.vue
@@ -1,15 +1,26 @@
 <template>
   <div>
-    <p v-if="employeeCode">{{ $t("app.employee_code", { employeeCode }) }}</p>
-    <p v-if="termsOfUse">{{ $t("checkbox.check") }}</p>
-    <p v-else>{{ $t("checkbox.checknull") }}</p>
+    <p v-if="employeeCode">
+      {{ $t("app.employee_code", { employeeCode }) }}
+    </p>
+    <DemoAppCheckboxDisplay
+      :isChecked="termsOfUse"
+      :checkedText="$t('checkbox.check')"
+      :uncheckedText="$t('app.prop_emit.user.checkbox.checknull')"
+    />
   </div>
 </template>
 
 <script>
 import { Component, Prop, Vue } from "vue-property-decorator";
+import DemoAppCheckboxDisplay from "@/components/parts/DemoAppBooleanDisplay.vue";
 
-@Component({ name: "EmployeeCodeDisplay" })
+@Component({
+  name: "EmployeeCodeDisplay",
+  components: {
+    DemoAppCheckboxDisplay, // チェックボックス表示用コンポーネントをインポート
+  },
+})
 export default class EmployeeCodeDisplay extends Vue {
   @Prop(String) employeeCode;
   @Prop(Boolean) termsOfUse;

--- a/src/components/project/EmployeeCodeDisplay.vue
+++ b/src/components/project/EmployeeCodeDisplay.vue
@@ -5,8 +5,8 @@
     </p>
     <DemoAppCheckboxDisplay
       :isChecked="isSubscribed"
-      :checkedText="$t('app.prop_emit.user.checkbox.check')"
-      :uncheckedText="$t('app.prop_emit.user.checkbox.checknull')"
+      :checkedText="$t('app.prop_emit.employee.checkbox.check')"
+      :uncheckedText="$t('app.prop_emit.employee.checkbox.checknull')"
     />
   </div>
 </template>

--- a/src/components/project/EmployeeCodeInput.vue
+++ b/src/components/project/EmployeeCodeInput.vue
@@ -10,9 +10,12 @@
       v-model="inputEmployeeCode"
     />
 
-    <button class="form-button" @click="submitEmployeeCode">
-      {{ $t("button.submit") }}
-    </button>
+    <DemoAppButton
+      :loading="loading"
+      :disabled="inputEmployeeCode.trim() === ''"
+      :label="$t('button.submit')"
+      @click="submitEmployeeCode"
+    />
 
     <div class="checkbox-group">
       <label>
@@ -27,12 +30,19 @@
 
 <script>
 import { Component, Vue } from "vue-property-decorator";
+import DemoAppButton from "@/components/parts/DemoAppButton.vue";
 
-@Component({ name: "EmployeeCodeInput" })
+@Component({
+  name: "EmployeeCodeInput",
+  components: {
+    DemoAppButton,
+  },
+})
 export default class EmployeeCodeInput extends Vue {
   inputEmployeeCode = "";
   termsOfUse = false;
   errorMessage = "";
+  loading = false;
 
   submitEmployeeCode() {
     if (this.inputEmployeeCode.trim() === "") {
@@ -63,20 +73,6 @@ export default class EmployeeCodeInput extends Vue {
   font-size: 16px;
   border: 1px solid var(--vue-green);
   border-radius: 8px;
-}
-
-.form-button {
-  padding: 6px 20px;
-  border-radius: 20px;
-  border: 1px solid var(--dark-gray);
-  background: transparent;
-  cursor: pointer;
-  transition: 0.3s;
-}
-
-.form-button:hover {
-  background-color: var(--vue-green);
-  color: white;
 }
 
 .checkbox-group {

--- a/src/components/project/EmployeeCodeInput.vue
+++ b/src/components/project/EmployeeCodeInput.vue
@@ -10,7 +10,7 @@
 
     <DemoAppCheckbox
       v-model="isSubscribed"
-      :label="$t('app.prop_emit.user.checkbox.title')"
+      :label="$t('app.prop_emit.employee.checkbox.title')"
     />
 
      <DemoAppButton @click="submitEmployeeCode" :label="$t('button.submit')" />

--- a/src/components/project/EmployeeCodeInput.vue
+++ b/src/components/project/EmployeeCodeInput.vue
@@ -10,6 +10,11 @@
       v-model="inputEmployeeCode"
     />
 
+    <div class="checkbox-group">
+      <!-- DemoAppCheckbox を使用して termsOfUse とバインド -->
+      <DemoAppCheckbox v-model="termsOfUse" :label="$t('app.prop_emit.user.checkbox.title')" />
+    </div>
+
     <DemoAppButton
       :loading="loading"
       :disabled="inputEmployeeCode.trim() === ''"
@@ -17,12 +22,7 @@
       @click="submitEmployeeCode"
     />
 
-    <div class="checkbox-group">
-      <label>
-        <input type="checkbox" v-model="termsOfUse" />
-        {{ $t("checkbox.title") }}
-      </label>
-    </div>
+
 
     <p v-if="errorMessage" class="error-message">{{ errorMessage }}</p>
   </div>
@@ -31,11 +31,13 @@
 <script>
 import { Component, Vue } from "vue-property-decorator";
 import DemoAppButton from "@/components/parts/DemoAppButton.vue";
+import DemoAppCheckbox from "@/components/parts/DemoAppCheckbox.vue";
 
 @Component({
   name: "EmployeeCodeInput",
   components: {
     DemoAppButton,
+    DemoAppCheckbox, // コンポーネントを登録
   },
 })
 export default class EmployeeCodeInput extends Vue {

--- a/src/components/project/EmployeeCodeInput.vue
+++ b/src/components/project/EmployeeCodeInput.vue
@@ -1,8 +1,6 @@
 <template>
   <div class="form-group">
-    <label for="employee-code">{{
-      $t("app.prop_emit.employee.navigate")
-    }}</label>
+    <label for="employee-code">{{$t("app.prop_emit.employee.navigate")}}</label>
     <input
       class="form-input"
       type="text"
@@ -10,19 +8,12 @@
       v-model="inputEmployeeCode"
     />
 
-    <div class="checkbox-group">
-      <!-- DemoAppCheckbox を使用して termsOfUse とバインド -->
-      <DemoAppCheckbox v-model="termsOfUse" :label="$t('app.prop_emit.user.checkbox.title')" />
-    </div>
-
-    <DemoAppButton
-      :loading="loading"
-      :disabled="inputEmployeeCode.trim() === ''"
-      :label="$t('button.submit')"
-      @click="submitEmployeeCode"
+    <DemoAppCheckbox
+      v-model="isSubscribed"
+      :label="$t('app.prop_emit.user.checkbox.title')"
     />
 
-
+     <DemoAppButton @click="submitEmployeeCode" :label="$t('button.submit')" />
 
     <p v-if="errorMessage" class="error-message">{{ errorMessage }}</p>
   </div>
@@ -42,7 +33,7 @@ import DemoAppCheckbox from "@/components/parts/DemoAppCheckbox.vue";
 })
 export default class EmployeeCodeInput extends Vue {
   inputEmployeeCode = "";
-  termsOfUse = false;
+  isSubscribed = false;
   errorMessage = "";
   loading = false;
 
@@ -55,7 +46,7 @@ export default class EmployeeCodeInput extends Vue {
     this.$emit(
       "employee-code-submitted",
       this.inputEmployeeCode,
-      this.termsOfUse
+      this.isSubscribed
     );
   }
 }

--- a/src/components/project/UserNameDisplay.vue
+++ b/src/components/project/UserNameDisplay.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script>
-import { Component, Prop, Vue } from "vue-property-decorator";
+import { Component, Prop, Vue, Watch } from "vue-property-decorator";
 import DemoAppCheckboxDisplay from "@/components/parts/DemoAppBooleanDisplay.vue";
 
 @Component({
@@ -24,6 +24,13 @@ import DemoAppCheckboxDisplay from "@/components/parts/DemoAppBooleanDisplay.vue
 export default class UsernameDisplay extends Vue {
   @Prop({ type: String, default: "" }) username;
   @Prop({ type: Boolean, default: false }) isSubscribed;
+
+  isSubscribed = this.isSubscribed; // ローカルデータとして持つ
+
+  @Watch("isSubscribed") // 親から渡ってきた値が変更されたら、ローカルデータを更新
+  onIsSubscribedChanged(newValue) {
+    this.isSubscribed = newValue;
+  }
 }
 </script>
 

--- a/src/components/project/UserNameDisplay.vue
+++ b/src/components/project/UserNameDisplay.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script>
-import { Component, Prop, Vue, Watch } from "vue-property-decorator";
+import { Component, Prop, Vue } from "vue-property-decorator";
 import DemoAppCheckboxDisplay from "@/components/parts/DemoAppBooleanDisplay.vue";
 
 @Component({
@@ -25,12 +25,6 @@ export default class UsernameDisplay extends Vue {
   @Prop({ type: String, default: "" }) username;
   @Prop({ type: Boolean, default: false }) isSubscribed;
 
-  isSubscribed = this.isSubscribed; // ローカルデータとして持つ
-
-  @Watch("isSubscribed") // 親から渡ってきた値が変更されたら、ローカルデータを更新
-  onIsSubscribedChanged(newValue) {
-    this.isSubscribed = newValue;
-  }
 }
 </script>
 

--- a/src/components/project/UserNameDisplay.vue
+++ b/src/components/project/UserNameDisplay.vue
@@ -24,7 +24,6 @@ import DemoAppCheckboxDisplay from "@/components/parts/DemoAppBooleanDisplay.vue
 export default class UsernameDisplay extends Vue {
   @Prop({ type: String, default: "" }) username;
   @Prop({ type: Boolean, default: false }) isSubscribed;
-
 }
 </script>
 

--- a/src/components/project/UserNameInput.vue
+++ b/src/components/project/UserNameInput.vue
@@ -41,7 +41,6 @@ export default class UserNameInput extends Vue {
       this.errorMessage = this.$t("error.empty_username");
       return;
     }
-    console.log(this.isSubscribed);
     
     this.errorMessage = "";
     this.$emit("username-submitted", this.inputUsername, this.isSubscribed);

--- a/src/components/project/UserNameInput.vue
+++ b/src/components/project/UserNameInput.vue
@@ -41,8 +41,15 @@ export default class UserNameInput extends Vue {
       this.errorMessage = this.$t("error.empty_username");
       return;
     }
+    console.log(this.isSubscribed);
+    
     this.errorMessage = "";
     this.$emit("username-submitted", this.inputUsername, this.isSubscribed);
+  }
+
+  updateSubscription(value) {
+    this.isSubscribed = value; // ローカルで更新
+    this.$emit("update:isSubscribed", value); // 親に通知
   }
 }
 </script>

--- a/src/pages/Chapter1PropEmit.vue
+++ b/src/pages/Chapter1PropEmit.vue
@@ -49,7 +49,6 @@ export default {
   },
   methods: {
     onUsernameSubmitted(username, isSubscribed) {
- 
       this.username = username;
       this.isSubscribed = isSubscribed;
     },

--- a/src/pages/Chapter1PropEmit.vue
+++ b/src/pages/Chapter1PropEmit.vue
@@ -55,7 +55,6 @@ export default {
     onEmployeeCodeSubmitted(employeeCode, isSubscribed) {
       this.employeeCode = employeeCode;
       this.isSubscribed = isSubscribed;
-      console.log("isSubscribed",this.isSubscribed)
     },
     onGenderUpdated(gender) {
       this.gender = gender;

--- a/src/pages/Chapter1PropEmit.vue
+++ b/src/pages/Chapter1PropEmit.vue
@@ -16,7 +16,7 @@
         <EmployeeCodeInput @employee-code-submitted="onEmployeeCodeSubmitted" />
         <EmployeeCodeDisplay
           :employeeCode="employeeCode"
-          :isSubscribed="isSubscribed"
+          :isSubscribed="isEmployeeSubscribed"
         />
       </div>
     </div>
@@ -45,6 +45,9 @@ export default {
       employeeCode: "",
       termsOfUse: false,
       gender: "",
+
+      isUserSubscribed: false,    
+      isEmployeeSubscribed: false, 
     };
   },
   methods: {
@@ -54,7 +57,7 @@ export default {
     },
     onEmployeeCodeSubmitted(employeeCode, isSubscribed) {
       this.employeeCode = employeeCode;
-      this.isSubscribed = isSubscribed;
+      this.isEmployeeSubscribed = isSubscribed;
     },
     onGenderUpdated(gender) {
       this.gender = gender;

--- a/src/pages/Chapter1PropEmit.vue
+++ b/src/pages/Chapter1PropEmit.vue
@@ -49,12 +49,14 @@ export default {
   },
   methods: {
     onUsernameSubmitted(username, isSubscribed) {
+ 
       this.username = username;
       this.isSubscribed = isSubscribed;
     },
-    onEmployeeCodeSubmitted(employeeCode, termsOfUse) {
+    onEmployeeCodeSubmitted(employeeCode, isSubscribed) {
       this.employeeCode = employeeCode;
-      this.termsOfUse = termsOfUse;
+      this.isSubscribed = isSubscribed;
+      console.log("isSubscribed",this.isSubscribed)
     },
     onGenderUpdated(gender) {
       this.gender = gender;


### PR DESCRIPTION
▪️見た目
- 社員コードの送信ボタンの表示崩れを編集
- チェックボックス
  - I18n対応
  - コンポーネントのレンダリング順変更
  - サイズ変更


before------------
![スクリーンショット 2025-03-27 20 07 29](https://github.com/user-attachments/assets/a8ad25d1-4951-4901-81e8-5006b00830a6)


after------------
<img width="573" alt="スクリーンショット 2025-03-31 15 03 18" src="https://github.com/user-attachments/assets/26ea9a27-c394-4d72-b60e-96bec0e14136" />




▪️動作
ユーザー名入力欄をもとに、社員コード入力欄で以下の通り実装

- 社員コード空文字時のエラーの出現
- 社員コード入力し、送信ボタン押下後の「社員コードは⚪︎⚪︎⚪︎です」の表示
- チェックボックスの有無により、送信ボタンをトリガーに、チェック状況「チェック済/チェックしていません。」を表示


証跡動画------------



https://github.com/user-attachments/assets/df1c73f8-8b70-43ba-914a-a4ca0c7f782e




